### PR TITLE
feat/#15: Button 컴포넌트 구현

### DIFF
--- a/fe/src/components/Button/Button.stories.tsx
+++ b/fe/src/components/Button/Button.stories.tsx
@@ -1,0 +1,73 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Button } from './Button';
+import { icons } from '@components/Icon/Icon';
+
+const meta = {
+  title: 'Component/Button',
+  component: Button,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    size: {
+      control: { type: 'radio' },
+      description: '`S | M | L`',
+      options: ['S', 'M', 'L'],
+    },
+    icon: {
+      control: { type: 'select' },
+      description: '`string`',
+      defaultValue: 'plus',
+      options: Object.keys(icons),
+    },
+    text: {
+      control: { type: 'text' },
+      description: '`string`',
+      defaultValue: '텍스트',
+    },
+    backgroundColor: {
+      control: { type: 'radio' },
+      description: '`string`',
+      options: ['accentPrimary', 'accentText'],
+    },
+    onClick: { description: '`() => void`' },
+  },
+} satisfies Meta<typeof Button>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const TextOnlyL: Story = {
+  args: {
+    size: 'L',
+    backgroundColor: 'accentPrimary',
+    text: '로그아웃',
+  },
+};
+
+export const TextIconL: Story = {
+  args: {
+    size: 'L',
+    icon: 'plus',
+    backgroundColor: 'accentPrimary',
+    text: '위치 추가',
+  },
+};
+
+export const TextIconM: Story = {
+  args: {
+    size: 'M',
+    icon: 'plus',
+    backgroundColor: 'accentText',
+    text: '추가',
+  },
+};
+
+export const TextOnlyS: Story = {
+  args: {
+    size: 'S',
+    backgroundColor: 'accentPrimary',
+    text: '대화 중인 채팅방',
+  },
+};

--- a/fe/src/components/Button/Button.tsx
+++ b/fe/src/components/Button/Button.tsx
@@ -1,0 +1,64 @@
+import styled from 'styled-components';
+import React, { ButtonHTMLAttributes } from 'react';
+import { Icon, icons } from '@components/Icon/Icon';
+
+/* 분리하기 */
+const BUTTON_STYLE = {
+  S: { width: 'inhernt', padding: '8px 16px', font: 'availableStrong12' },
+  M: { width: '288px', padding: '16px', font: 'availableStrong16' },
+  L: { width: '329px', padding: '16px', font: 'availableStrong16' },
+};
+
+export type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  backgroundColor: string;
+  size: 'S' | 'M' | 'L';
+  text: string;
+  icon?: keyof typeof icons;
+};
+
+export const Button: React.FC<ButtonProps> = ({
+  backgroundColor,
+  type = 'button',
+  size,
+  icon,
+  text,
+  ...props
+}) => {
+  const iconColor =
+    backgroundColor === 'accentPrimary' ? 'accentText' : 'accentTextWeak';
+
+  return (
+    <StyledButton
+      type={type}
+      $backgroundColor={backgroundColor}
+      size={size}
+      {...props}
+    >
+      {icon && <Icon name={icon} stroke={iconColor} />}
+      {text}
+    </StyledButton>
+  );
+};
+
+const StyledButton = styled.button<{
+  $backgroundColor: string;
+  size: 'S' | 'M' | 'L';
+}>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  width: ${({ size }) => BUTTON_STYLE[size].width};
+  padding: ${({ size }) => BUTTON_STYLE[size].padding};
+  font: ${({ theme: { font }, size }) => font[BUTTON_STYLE[size].font]};
+  border-radius: ${({ theme: { radius } }) => radius.small};
+  border: 0.8px solid;
+  border-color: ${({ theme: { color }, $backgroundColor }) =>
+    $backgroundColor === 'accentPrimary' ? 'none' : color.neutralBorder};
+  background-color: ${({ theme: { color }, $backgroundColor }) =>
+    color[$backgroundColor]};
+  color: ${({ theme: { color }, $backgroundColor }) =>
+    $backgroundColor === 'accentPrimary'
+      ? color.accentText
+      : color.accentTextWeak};
+`;

--- a/fe/src/styles/DesignSystem.ts
+++ b/fe/src/styles/DesignSystem.ts
@@ -42,4 +42,11 @@ export const theme = {
     enabledStrong16: fonts.bold16,
     enabledStrong10: fonts.bold10,
   },
+
+  radius: {
+    half: '50%',
+    small: '8px',
+    medium: '12px',
+    large: '16px',
+  },
 };


### PR DESCRIPTION
## Key changes

- 버튼 컴포넌트 구현

## To 리태 👋

디자인시스템에 `radius`값이 따로 없어서 추가 해줬어요! 
저번 이름은 프로젝트에서 그대로 가져왔고 `small`만 추가해줬습니다.
```
  radius: {
    half: '50%',
    small: '8px',
    medium: '12px',
    large: '16px',
  },
```
그리고 '대화 중인 채팅방' 작은 버튼까지 같이 만들었어요! 나중에 확인해주시고 갈아 끼면 될 것 같습니다! 
```
<Button
  backgroundColor="accentPrimary"
  onClick={() => {}}
  size="S"
  text="대화 중인 채팅방"
/>
```

아래는 미리보기 🐶

![image](https://github.com/masters2023-project-06-second-hand/second-hand-fe/assets/95265031/b220ffd6-b87b-4308-8156-e88e14cd8ade)
