### PR TITLE
Feat/#118 feat toast 구현하기

### DIFF
--- a/fe/src/App.tsx
+++ b/fe/src/App.tsx
@@ -5,6 +5,7 @@ import { ThemeProvider } from 'styled-components';
 import { RouterProvider } from 'react-router-dom';
 import { Loading } from '@pages/Loading';
 import { GlobalModal } from '@components/Modal/GlobalModal';
+import { Toast } from '@components/Toast/Toast';
 import router from '@routes/router';
 
 const queryClient = new QueryClient({
@@ -24,6 +25,7 @@ function App() {
         <ReactQueryDevtools initialIsOpen={false} />
         <ThemeProvider theme={theme}>
           <RouterProvider router={router} fallbackElement={<Loading />} />
+          <Toast />
           <GlobalModal />
         </ThemeProvider>
       </QueryClientProvider>

--- a/fe/src/api/auth/login.tsx
+++ b/fe/src/api/auth/login.tsx
@@ -6,6 +6,7 @@ import { useAtom, useSetAtom } from 'jotai';
 import { isLoginAtom, signupTokenAtom } from '@atoms/loginAtom';
 import { fetchUserInfo } from './userInfo';
 import { BASE_API_URL } from '../../envConfig';
+import { useToast } from '@components/Toast/useToast';
 
 /* TODO. 코드들 분리하기 */
 type LoginData = {
@@ -47,6 +48,7 @@ export const fetchSignup = async (body: SignupBody, signupToken: string) => {
 export const useHandleLogout = () => {
   const setUserInfo = useSetAtom(userInfoAtom);
   const setIsLogin = useSetAtom(isLoginAtom);
+  const toast = useToast();
 
   const logout = async () => {
     await fetchLogout();
@@ -56,7 +58,7 @@ export const useHandleLogout = () => {
 
     setUserInfo(null);
     setIsLogin(false);
-    console.log('isLogin : 로그아웃 됐어요');
+    toast.success('로그아웃 성공!');
   };
 
   return logout;
@@ -65,6 +67,7 @@ export const useHandleLogout = () => {
 export const useHandleLogin = () => {
   const setUserInfo = useSetAtom(userInfoAtom);
   const setIsLogin = useSetAtom(isLoginAtom);
+  const toast = useToast();
 
   return async (data: LoginData) => {
     try {
@@ -74,8 +77,7 @@ export const useHandleLogin = () => {
       const userInfo = await fetchUserInfo(data.memberId);
       setUserInfo(userInfo);
       setIsLogin(true);
-
-      console.log('isLogin : 로그인 됐어요');
+      toast.success('로그인 성공!');
     } catch (error) {
       console.error(
         'Error during fetching user info or setting tokens:',

--- a/fe/src/atoms/toastAtom.tsx
+++ b/fe/src/atoms/toastAtom.tsx
@@ -1,0 +1,15 @@
+import { atom } from 'jotai';
+
+type ToastState = {
+  message: string;
+  visible: boolean;
+  type: 'success' | 'error' | 'noti';
+};
+
+export const toastAtom = atom<ToastState>({
+  message: '',
+  visible: false,
+  type: 'noti',
+});
+
+export const animationAtom = atom<'slideUp' | 'slideDown' | null>(null);

--- a/fe/src/components/Toast/Toast.tsx
+++ b/fe/src/components/Toast/Toast.tsx
@@ -2,6 +2,7 @@ import ReactDOM from 'react-dom';
 import styled, { keyframes } from 'styled-components';
 import { useAtom } from 'jotai';
 import { toastAtom, animationAtom } from '@atoms/toastAtom';
+import { Icon } from '@components/Icon/Icon';
 
 export const Toast: React.FC = () => {
   const [toastState, setToastState] = useAtom(toastAtom);
@@ -23,6 +24,9 @@ export const Toast: React.FC = () => {
         $type={toastState.type}
         onAnimationEnd={handleAnimationEnd}
       >
+        {toastState.type === 'error' && (
+          <Icon fill="#ff6243" name="circleXFilled" stroke="none" />
+        )}
         <p>{toastState.message}</p>
       </Text>
     </ToastWrapper>,
@@ -74,14 +78,13 @@ const Text = styled.div<{
   bottom: 70px;
   padding: 8px 16px;
   width: ${({ $type }) => ($type === 'success' ? 'max-content' : '100%')};
-  background-color: ${({ $type }) =>
-    $type === 'error' ? '#ff6243' : '#212123'};
-  border: 1px solid transparent;
+  background-color: ${({ $type }) => ($type === 'error' ? '#fff' : '#212123')};
+  border: 1px solid;
   border-radius: ${({ $type, theme: { radius } }) =>
     $type === 'success' ? radius.large : radius.small};
   font: ${({ $type, theme: { font } }) =>
     $type === 'error' ? font.availableStrong12 : font.displayDefault12};
-  color: #e2e2e2;
+  color: ${({ $type }) => ($type === 'error' ? '#ff6243' : '#e2e2e2')};
   z-index: 1000;
   transform: translateX(-50%) translateY(0);
   animation:

--- a/fe/src/components/Toast/Toast.tsx
+++ b/fe/src/components/Toast/Toast.tsx
@@ -1,0 +1,95 @@
+import ReactDOM from 'react-dom';
+import styled, { keyframes } from 'styled-components';
+import { useAtom } from 'jotai';
+import { toastAtom, animationAtom } from '@atoms/toastAtom';
+
+export const Toast: React.FC = () => {
+  const [toastState, setToastState] = useAtom(toastAtom);
+  const [animation, setAnimation] = useAtom(animationAtom);
+
+  const handleAnimationEnd = () => {
+    if (animation === 'slideDown') {
+      setToastState((prev) => ({ ...prev, visible: false }));
+      setAnimation(null);
+    }
+  };
+
+  if (animation === null) return null;
+
+  return ReactDOM.createPortal(
+    <ToastWrapper>
+      <Text
+        $animation={animation || 'slideDown'}
+        $type={toastState.type}
+        onAnimationEnd={handleAnimationEnd}
+      >
+        <p>{toastState.message}</p>
+      </Text>
+    </ToastWrapper>,
+    document.body
+  );
+};
+
+const slideUp = keyframes`
+  from {
+    transform: translateY(100%);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+`;
+
+const slideDown = keyframes`
+  from {
+    transform: translateY(0);
+    opacity: 1;
+  }
+  to {
+    transform: translateY(100%);
+    opacity: 0;
+  }
+`;
+
+const ToastWrapper = styled.div`
+  width: 377px;
+  margin: 0 auto;
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+/* 디자인이 따로 정해져있는게 없어서 그냥 막 작성합니다 ^^... */
+const Text = styled.div<{
+  $animation: 'slideUp' | 'slideDown';
+  $type: 'success' | 'error' | 'noti';
+}>`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0;
+  position: absolute;
+  bottom: 70px;
+  padding: 8px 16px;
+  width: ${({ $type }) => ($type === 'success' ? 'max-content' : '100%')};
+  background-color: ${({ $type }) =>
+    $type === 'error' ? '#ff6243' : '#212123'};
+  border: 1px solid transparent;
+  border-radius: ${({ $type, theme: { radius } }) =>
+    $type === 'success' ? radius.large : radius.small};
+  font: ${({ $type, theme: { font } }) =>
+    $type === 'error' ? font.availableStrong12 : font.displayDefault12};
+  color: #e2e2e2;
+  z-index: 1000;
+  transform: translateX(-50%) translateY(0);
+  animation:
+    ${slideUp} 0.3s,
+    ${slideDown} 0.3s 2.7s;
+  animation-fill-mode: forwards;
+  animation: ${({ $animation }) =>
+      $animation === 'slideUp' ? slideUp : slideDown}
+    0.3s;
+  animation-fill-mode: forwards;
+`;

--- a/fe/src/components/Toast/useToast.tsx
+++ b/fe/src/components/Toast/useToast.tsx
@@ -1,0 +1,45 @@
+import { useSetAtom } from 'jotai';
+import { toastAtom, animationAtom } from '@atoms/toastAtom';
+
+type ToastOptions = {
+  text: string;
+  type: 'success' | 'error' | 'noti';
+};
+
+export function useToast() {
+  const setToastState = useSetAtom(toastAtom);
+  const setAnimation = useSetAtom(animationAtom);
+
+  const show = (options: ToastOptions) => {
+    const { text, type = 'noti' } = options;
+
+    setToastState({
+      message: text,
+      visible: true,
+      type,
+    });
+    setAnimation('slideUp');
+
+    setTimeout(() => {
+      setAnimation('slideDown');
+    }, 2700);
+
+    setTimeout(() => {
+      setToastState((prev) => ({ ...prev, visible: false }));
+    }, 3000);
+  };
+
+  const success = (message: string) => {
+    show({ text: message, type: 'success' });
+  };
+
+  const error = (message: string) => {
+    show({ text: message, type: 'error' });
+  };
+
+  const noti = (message: string) => {
+    show({ text: message, type: 'noti' });
+  };
+
+  return { success, error, noti };
+}


### PR DESCRIPTION
## Key changes

- Toast 구현

## To reviewers 👋

#### Toast 종류 : `'noti'` `'success'` `'error'`
  - `noti` : 상태 변경용 or 설명 or 알림 등에 알잘딱 사용
    ![image](https://github.com/masters2023-project-06-second-hand/second-hand-fe/assets/95265031/d4cbfa15-c991-4dab-bcba-526d4beebe78)


  - `success` : 성공 했을 경우 사용
  ![image](https://github.com/masters2023-project-06-second-hand/second-hand-fe/assets/95265031/fa752443-1cb1-4b93-b304-9444d9d6d4c4)


  - `error` : 에러일 경우 사용
  ![image](https://github.com/masters2023-project-06-second-hand/second-hand-fe/assets/95265031/11c4e2dd-e8a4-4758-b83c-d89065d52952)


#### 사용법

1. 원하는 곳에서 토스트기를 가져온다. `const toast = useToast();` 
2. 종류와 텍스트를 넣는다 `toast.success('로그아웃 성공!');`
3. 굽기 완성

```javascript
export const useHandleLogout = () => {
  const toast = useToast();

  const logout = async () => {
    toast.success('로그아웃 성공!');
  };

  return logout;
};
```
